### PR TITLE
Enforce LF line endings for bash scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Necessay to allow for Linux/Ubuntu terminals to run the script, as the VSCode default
+# forces CRLF line endings without this, which doesn't work in Linux/Ubuntu terminals
+*.sh text eol=lf


### PR DESCRIPTION
this is necessary for our code to run properly on the Linux/Ubuntu terminal